### PR TITLE
BUG: register missing ViewHelper arguments

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -280,8 +280,8 @@ class ModuleController extends ActionController
 
         $vocabulary = $taxonomyRoot->createNodeFromTemplate($nodeTemplate);
 
-        $this->flashMessageContainer->addMessage(
-            new Message(sprintf('Created vocabulary %s at path %s', $title, $vocabulary->getPath()))
+        $this->addFlashMessage(
+            sprintf('Created vocabulary %s at path %s', $title, $vocabulary->getPath())
         );
         $this->redirect('index', null, null, ['root' => $taxonomyRoot]);
     }
@@ -322,7 +322,9 @@ class ModuleController extends ActionController
             $vocabulary->setProperty('description', $description);
         }
 
-        $this->flashMessageContainer->addMessage(new Message(sprintf('Updated vocabulary %s', $title)));
+        $this->addFlashMessage(
+            sprintf('Updated vocabulary %s', $title)
+        );
         $this->redirect('index', null, null, ['root' => $taxonomyRoot]);
     }
 
@@ -340,7 +342,9 @@ class ModuleController extends ActionController
         } else {
             $path = $vocabulary->getPath();
             $vocabulary->remove();
-            $this->flashMessageContainer->addMessage(new Message(sprintf('Deleted vocabulary %s', $path)));
+            $this->addFlashMessage(
+                sprintf('Deleted vocabulary %s', $path)
+            );
         }
         $taxonomyRoot = $this->taxonomyService->getRoot($vocabulary->getContext());
         $this->redirect('index', null, null, ['root' => $taxonomyRoot]);
@@ -378,8 +382,8 @@ class ModuleController extends ActionController
 
         $taxonomy = $parent->createNodeFromTemplate($nodeTemplate);
 
-        $this->flashMessageContainer->addMessage(
-            new Message(sprintf('Created taxonomy %s at path %s', $title, $taxonomy->getPath()))
+        $this->addFlashMessage(
+            sprintf('Created taxonomy %s at path %s', $title, $taxonomy->getPath())
         );
 
         $flowQuery = new FlowQuery([$taxonomy]);
@@ -437,7 +441,9 @@ class ModuleController extends ActionController
             $taxonomy->setProperty('description', $description);
         }
 
-        $this->flashMessageContainer->addMessage(new Message(sprintf('Updated taxonomy %s', $taxonomy->getPath())));
+        $this->addFlashMessage(
+            sprintf('Updated taxonomy %s', $taxonomy->getPath())
+        );
 
         $flowQuery = new FlowQuery([$taxonomy]);
         $vocabulary = $flowQuery
@@ -466,7 +472,10 @@ class ModuleController extends ActionController
 
         $taxonomy->remove();
 
-        $this->flashMessageContainer->addMessage(new Message(sprintf('Deleted taxonomy %s', $taxonomy->getPath())));
+        $this->addFlashMessage(
+            sprintf('Deleted taxonomy %s', $taxonomy->getPath())
+        );
+
         $this->redirect('vocabulary', null, null, ['vocabulary' => $vocabulary]);
     }
 }

--- a/Classes/ViewHelpers/DimensionInformationViewHelper.php
+++ b/Classes/ViewHelpers/DimensionInformationViewHelper.php
@@ -16,7 +16,7 @@ class DimensionInformationViewHelper extends AbstractViewHelper
      */
     public function initializeArguments()
     {
-        $this->registerArgument('node', NodeInterface::class, 'Node', true);
+        $this->registerArgument('node', NodeInterface::class, 'Node', false);
         $this->registerArgument('dimension', 'string', 'Dimension', false, null);
     }
     

--- a/Classes/ViewHelpers/DimensionInformationViewHelper.php
+++ b/Classes/ViewHelpers/DimensionInformationViewHelper.php
@@ -7,6 +7,19 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 class DimensionInformationViewHelper extends AbstractViewHelper
 {
+    
+    /**
+     * Initialize arguments.
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('node', NodeInterface::class, 'Node', true);
+        $this->registerArgument('dimension', 'string', 'Dimension', false, null);
+    }
+    
     /**
      * @param NodeInterface $node
      * @param string $dimension dimension name


### PR DESCRIPTION
if not set the following Exception will be thrown if the the ViewHelper ist not cached -> php 7.3 | Neos 5.1
Undeclared arguments passed to ViewHelper Sitegeist\Taxonomy\ViewHelpers\DimensionInformationViewHelper: node, dimension.