### PR TITLE
BUG: fix dimensionInformatonViewHelper

### DIFF
--- a/Classes/ViewHelpers/DimensionInformationViewHelper.php
+++ b/Classes/ViewHelpers/DimensionInformationViewHelper.php
@@ -21,17 +21,15 @@ class DimensionInformationViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param NodeInterface $node
-     * @param string $dimension dimension name
      * @return string value with replaced text
      * @api
      */
-    public function render(NodeInterface $node, $dimension = null)
+    public function render()
     {
         return self::renderStatic(
             [
-                'node' => $node,
-                'dimension' =>  $dimension
+                'node' => $this->arguments['node'],
+                'dimension' =>  $this->arguments['dimension']
             ],
             $this->buildRenderChildrenClosure(),
             $this->renderingContext


### PR DESCRIPTION
The render method should be declared without arguments according to the fluid core view helpers. This causes an issue while determining the root node what could potentially lead to a wrong behavior