### PR TITLE
FEATURE: Make taxonomies sortable

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -274,12 +274,6 @@ class ModuleController extends ActionController
         $this->view->assign('vocabulary', $vocabulary);
         $this->view->assign('defaultVocabulary', $this->getNodeInDefaultDimensions($vocabulary));
         $taxonomies = $this->fetchChildTaxonomies($vocabulary);
-        usort($taxonomies, function (array $taxonomyA, array $taxonomyB) {
-            return strcmp(
-                $taxonomyA['node']->getProperty('title') ?: '',
-                $taxonomyB['node']->getProperty('title') ?: ''
-            );
-        });
         $this->view->assign('taxonomies', $taxonomies);
     }
 
@@ -501,7 +495,7 @@ class ModuleController extends ActionController
     public function deleteTaxonomyAction(NodeInterface $taxonomy)
     {
         if ($taxonomy->isAutoCreated()) {
-            throw new \Exception('cannot delete autocrated taxonomies');
+            throw new \Exception('cannot delete autocreated taxonomies');
         }
 
         $flowQuery = new FlowQuery([$taxonomy]);
@@ -518,5 +512,66 @@ class ModuleController extends ActionController
         $this->redirect('vocabulary', null, null, ['vocabulary' => $vocabulary]);
     }
 
+    /**
+     * Move taxonomy up
+     *
+     * @param NodeInterface $taxonomy
+     * @return void
+     */
+    public function moveUpTaxonomyAction(NodeInterface $taxonomy)
+    {
+        $this->persistenceManager->allowObject($taxonomy);
+
+        $flowQuery = new FlowQuery([$taxonomy]);
+        $nextSiblingNode = $flowQuery->prev()->get(0);
+        $taxonomy->moveBefore($nextSiblingNode);
+        $this->persistenceManager->persistAll();
+
+        foreach ($taxonomy->getOtherNodeVariants() as $otherNodeVariant) {
+            $otherNodeVariant->setIndex($taxonomy->getIndex());
+        }
+        $this->persistenceManager->persistAll();
+
+        $this->addFlashMessage(
+            sprintf('Moved up taxonomy %s', $taxonomy->getPath())
+        );
+
+        $vocabulary = $flowQuery
+            ->closest('[instanceof ' . $this->taxonomyService->getVocabularyNodeType() . ']')
+            ->get(0);
+
+        $this->redirect('vocabulary', null, null, ['vocabulary' => $vocabulary]);
+    }
+
+    /**
+     * Move taxonomy down
+     *
+     * @param NodeInterface $taxonomy
+     * @return void
+     */
+    public function moveDownTaxonomyAction(NodeInterface $taxonomy)
+    {
+        $this->persistenceManager->allowObject($taxonomy);
+
+        $flowQuery = new FlowQuery([$taxonomy]);
+        $nextSiblingNode = $flowQuery->next()->get(0);
+        $taxonomy->moveAfter($nextSiblingNode);
+        $this->persistenceManager->persistAll();
+
+        foreach ($taxonomy->getOtherNodeVariants() as $otherNodeVariant) {
+            $otherNodeVariant->setIndex($taxonomy->getIndex());
+        }
+        $this->persistenceManager->persistAll();
+
+        $this->addFlashMessage(
+            sprintf('Moved down taxonomy %s', $taxonomy->getPath())
+        );
+
+        $vocabulary = $flowQuery
+            ->closest('[instanceof ' . $this->taxonomyService->getVocabularyNodeType() . ']')
+            ->get(0);
+
+        $this->redirect('vocabulary', null, null, ['vocabulary' => $vocabulary]);
+    }
 
 }

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -5,7 +5,7 @@ privilegeTargets:
     'Sitegeist.Taxonomy:Module.ManageVocabularyActions':
       matcher: 'method(Sitegeist\Taxonomy\Controller\ModuleController->(newVocabulary|createVocabulary|editVocabulary|updateVocabulary|deleteVocabulary)Action())'
     'Sitegeist.Taxonomy:Module.ManageTaxonomyActions':
-      matcher: 'method(Sitegeist\Taxonomy\Controller\ModuleController->(newTaxonomy|createTaxonomy|editTaxonomy|updateTaxonomy|deleteTaxonomy)Action())'
+      matcher: 'method(Sitegeist\Taxonomy\Controller\ModuleController->(newTaxonomy|createTaxonomy|editTaxonomy|updateTaxonomy|deleteTaxonomy|moveUpTaxonomy|moveDownTaxonomy)Action())'
     'Sitegeist.Taxonomy:SecondaryInspector.Tree':
       matcher: 'method(Sitegeist\Taxonomy\Controller\SecondaryInspectorController->treeAction())'
 

--- a/Resources/Private/Fusion/Backend/Views/Taxonomy.List.fusion
+++ b/Resources/Private/Fusion/Backend/Views/Taxonomy.List.fusion
@@ -42,7 +42,7 @@ prototype(Sitegeist.Taxonomy:Views.Module.Taxonomy.List) < prototype(Neos.Fusion
             </thead>
             <tbody>
             <Neos.Fusion:Loop items={taxonomies} itemName="taxon">
-                <Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item taxon={taxon}/>
+                <Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item taxon={taxon} isFirst={iterator.isFirst} isLast={iterator.isLast}/>
             </Neos.Fusion:Loop>
             </tbody>
         </table>
@@ -72,6 +72,8 @@ prototype(Sitegeist.Taxonomy:Views.Module.Taxonomy.List) < prototype(Neos.Fusion
 
 prototype(Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item) < prototype(Neos.Fusion:Component) {
     taxon = null
+    isFirst = false
+    isLast = false
 
     renderer = afx`
         <tr>
@@ -94,6 +96,26 @@ prototype(Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item) < prototype(Neos.F
 
                     <Neos.Fusion:Fragment @if={Security.hasAccess("Sitegeist.Taxonomy:Module.ManageTaxonomyActions")}>
 
+                        <Neos.Fusion:Link.Action
+                            @if={!props.isFirst}
+                            href.action="moveUpTaxonomy"
+                            href.arguments.taxonomy={props.taxon.node.contextPath}
+                            title={props.i8n.id('taxon.moveUp')}
+                            class="neos-button neos-button-primary"
+                        >
+                            <i class="fas fa-arrow-up"></i>
+                        </Neos.Fusion:Link.Action>
+                        <span @if={props.isFirst} class="neos-button neos-disabled" style="width: 46px;"></span>
+                        <Neos.Fusion:Link.Action
+                            @if={!props.isLast}
+                            href.action="moveDownTaxonomy"
+                            href.arguments.taxonomy={props.taxon.node.contextPath}
+                            title={props.i8n.id('taxon.moveDown')}
+                            class="neos-button neos-button-primary"
+                        >
+                            <i class="fas fa-arrow-down"></i>
+                        </Neos.Fusion:Link.Action>
+                        <span @if={props.isLast} class="neos-button neos-disabled" style="width: 46px;"></span>
                         <Neos.Fusion:Link.Action
                             href.action="newTaxonomy"
                             href.arguments.parent={props.taxon.node.contextPath}
@@ -149,7 +171,7 @@ prototype(Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item) < prototype(Neos.F
         </tr>
 
         <Neos.Fusion:Loop items={props.taxon.children} itemName="child">
-            <Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item taxon={child}/>
+            <Sitegeist.Taxonomy:Views.Module.Taxonomy.List.Item taxon={child} isFirst={iterator.isFirst} isLast={iterator.isLast}/>
         </Neos.Fusion:Loop>
 
     `


### PR DESCRIPTION
Since all Taxonomy items are nodes, the sortingIndex of the nodes is already respected. Instead of just having an alphabetical sorting by title, we allow sorting taxonomies in the backend module. This is helpful if taxonomies are used e.g. as a filter in the frontend and you explicitly want to sort the items.