### PR TITLE
[BUGFIX] Use context to get rootnode

### DIFF
--- a/Classes/Service/TaxonomyService.php
+++ b/Classes/Service/TaxonomyService.php
@@ -131,13 +131,10 @@ class TaxonomyService
             return $this->taxonomyDataRootNodes[$contextHash];
         }
 
-        // return existing root-node
-        //
-        // TODO: Find a better way to determine the root node
-        $taxonomyDataRootNodeData = $this->nodeDataRepository->findOneByPath(
-            '/' . $this->getRootNodeName(),
-            $context->getWorkspace()
-        );
+        $taxonomyDataRootNode = $context->getNode('/'.$this->getRootNodeName());
+        if ($taxonomyDataRootNode instanceof NodeInterface) {
+            $taxonomyDataRootNodeData = $taxonomyDataRootNode->getNodeData();
+        }
 
         if ($taxonomyDataRootNodeData !== null) {
             $this->taxonomyDataRootNodes[$contextHash] = $this->nodeFactory->createFromNodeData(


### PR DESCRIPTION
This will get the node from context instead of searching via nodeDataRepository, sometimes depending on the environment the `findOneByPath` returns `null` (in my case it was in the production environment, in ddev it worked just fine).