### PR TITLE
[BUGFIX] Handling of contentDimensions

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -180,7 +180,8 @@ class ModuleController extends ActionController
 
         $rootNode = $this->taxonomyService->getNodeByNodeAddress($rootNodeAddress);
         $subgraph = $this->taxonomyService->getSubgraphForNode($rootNode);
-        $generalizations = $contentRepository->getVariationGraph()->getRootGeneralizations();
+        $generalizations = $contentRepository->getVariationGraph()->getDimensionSpacePoints() ? $contentRepository->getVariationGraph()->getDimensionSpacePoints() : $contentRepository->getVariationGraph()->getRootGeneralizations();
+
         $nodeAddress = NodeAddress::fromJsonString($rootNodeAddress);
         $originDimensionSpacePoint = OriginDimensionSpacePoint::fromDimensionSpacePoint($nodeAddress->dimensionSpacePoint);
 
@@ -252,7 +253,6 @@ class ModuleController extends ActionController
     {
         $vocabularyNode = $this->taxonomyService->getNodeByNodeAddress($vocabularyNodeAddress);
         $subgraph = $this->contentRepositoryRegistry->subgraphForNode($vocabularyNode);
-        $rootNode = $this->taxonomyService->findOrCreateRoot($subgraph);
 
         $this->contentRepository->handle(
             SetNodeProperties::create(
@@ -283,7 +283,7 @@ class ModuleController extends ActionController
             );
         }
 
-        $this->redirect('index', null, null, ['rootNodeAddress' => NodeAddress::fromNode($rootNode)]);
+    	$this->redirect('index');
     }
 
     /**
@@ -350,7 +350,7 @@ class ModuleController extends ActionController
         }
         $subgraph = $this->taxonomyService->getSubgraphForNode($parentNode);
 
-        $generalizations = $this->contentRepository->getVariationGraph()->getRootGeneralizations();
+        $generalizations = $this->contentRepository->getVariationGraph()->getDimensionSpacePoints() ? $this->contentRepository->getVariationGraph()->getDimensionSpacePoints() : $this->contentRepository->getVariationGraph()->getRootGeneralizations();
         $nodeAddress = NodeAddress::fromJsonString($parentNodeAddress);
         $originDimensionSpacePoint = OriginDimensionSpacePoint::fromDimensionSpacePoint($nodeAddress->dimensionSpacePoint);
 

--- a/Resources/Private/Fusion/Backend/Fragments/DimensionSelector.fusion
+++ b/Resources/Private/Fusion/Backend/Fragments/DimensionSelector.fusion
@@ -21,13 +21,41 @@ prototype(Sitegeist.Taxonomy:Views.Fragments.DimensionSelector) < prototype(Neos
                     field.value={Neos.Dimension.currentValue(props.contextNode, dimensionKey).value}
                     attributes.onchange="this.form.submit()"
                 >
-                  <Neos.Fusion.Form:Select.Option >{String.firstLetterToUpperCase(dimensionKey)}: {Neos.Dimension.currentValue(props.contextNode, dimensionKey).value}</Neos.Fusion.Form:Select.Option>
-                  <Neos.Fusion:Loop items={dimension.values.rootValues} itemName="dimensionValue" itemKey="presetIdentifier">
-                        <Neos.Fusion.Form:Select.Option option.value={dimensionValue.value}>{String.firstLetterToUpperCase(dimensionKey)}: {dimensionValue.value}</Neos.Fusion.Form:Select.Option>
-                    </Neos.Fusion:Loop>
+                  <Sitegeist.Taxonomy:Views.Fragments.DimensionSelector.Options dimension={dimension} dimensionKey={dimensionKey} contextNode={props.contextNode} />
                 </Neos.Fusion.Form:Select>
             </Neos.Fusion:Loop>
-
         </Neos.Fusion.Form:Form>
     `
+}
+
+prototype(Sitegeist.Taxonomy:Views.Fragments.DimensionSelector.Options) < prototype(Neos.Fusion:Component) {
+  dimension = null
+  dimensionKey = null
+  contextNode = null
+
+  @context {
+    dimension = ${this.dimension}
+    dimensionKey = ${this.dimensionKey}
+    contextNode = ${this.contextNode}
+  }
+
+  renderer = Neos.Fusion:Case {
+    dimensionConfigured {
+      condition = ${dimension.values}
+      renderer = afx`
+        <Neos.Fusion:Loop items={dimension.values} itemName="dimensionValue" itemKey="presetIdentifier">
+          <Neos.Fusion.Form:Select.Option attributes.selected={Neos.Dimension.currentValue(contextNode, dimensionKey).value == dimensionValue.value} option.value={dimensionValue.value}>{String.firstLetterToUpperCase(dimensionKey)}: {dimensionValue.value}</Neos.Fusion.Form:Select.Option>
+        </Neos.Fusion:Loop>
+      `
+    }
+    default {
+      condition = ${dimension.rootValues}
+      renderer = afx`
+        <Neos.Fusion.Form:Select.Option >{String.firstLetterToUpperCase(dimensionKey)}: {Neos.Dimension.currentValue(props.contextNode, dimensionKey).value}</Neos.Fusion.Form:Select.Option>
+        <Neos.Fusion:Loop items={dimension.values.rootValues} itemName="dimensionValue" itemKey="presetIdentifier">
+          <Neos.Fusion.Form:Select.Option option.value={dimensionValue.value}>{String.firstLetterToUpperCase(dimensionKey)}: {dimensionValue.value}</Neos.Fusion.Form:Select.Option>
+        </Neos.Fusion:Loop>
+      `
+    }
+  }
 }


### PR DESCRIPTION
This adds 

1. for `CreateNodeVariant` to be created for all (if any) configured contentDimensions.

Before, both in `createVocabulary` and `createTaxonomy` there was only ever checked for `$contentRepository->getVariationGraph()->getRootGeneralizations()`, never for the actually present ones.

2. A conditonal `Sitegeist.Taxonomy:Views.Fragments.DimensionSelector.Options` prototype for option rendering based on configured (multiple) contentDimensions or the default. This now allows to correctly switch to all present contentDimensions. 

**Tested with Neos 9.0.7.**

Please verify :) I'm really not sure if this may be wrecking the default ("no" contentDimension) config in some places I did not think about.