### PR TITLE
explicitly mark optional parameters as nullable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
             matrix:
                 php-versions: ['8.2', '8.3']
                 neos-versions: ['9.0']
+                include:
+                  - php-versions: '8.4'
+                    neos-versions: '9.1'
 
         runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,6 @@ jobs:
                 composer update
 
             - name: Run Tests
-              run: composer test
+              run: |
+                composer install
+                composer lint

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -106,7 +106,7 @@ class ModuleController extends ActionController
     /**
      * Show an overview of available vocabularies
      */
-    public function indexAction(string $rootNodeAddress = null): void
+    public function indexAction(?string $rootNodeAddress = null): void
     {
         if (is_null($rootNodeAddress)) {
             $subgraph = $this->taxonomyService->getDefaultSubgraph();

--- a/Classes/Controller/SecondaryInspectorController.php
+++ b/Classes/Controller/SecondaryInspectorController.php
@@ -76,7 +76,7 @@ class SecondaryInspectorController extends ActionController
     /**
      * @return mixed[]
      */
-    protected function toJson(Subtree $subtree, string $pathSoFar = null): array
+    protected function toJson(Subtree $subtree, ?string $pathSoFar = null): array
     {
         $label = $this->nodeLabelGenerator->getLabel($subtree->node);
         $pathSegment = $subtree->node->name?->value ?? $label;

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "neos/fusion-form": ">=2.1.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "~1.10.16",
+        "phpstan/phpstan": "~1.12.33",
         "squizlabs/php_codesniffer": "~3.7.2"
     },
     "autoload": {
@@ -27,7 +27,9 @@
         "test:lint-fix": ["phpcbf --standard=PSR12 -n Classes"],
         "test:lint": ["phpcs --standard=PSR12 -n Classes"],
         "test:stan": ["vendor/bin/phpstan analyse Classes"],
-        "test": ["composer install", "composer  test:lint", "composer  test:stan"]
+        "fix": ["composer test:lint-fix"],
+        "lint": ["composer test:lint", "composer test:stan"],
+        "test": ["echo 'not implemented yet'"]
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
To fix PHP 8.4 deprecation warnings.